### PR TITLE
feat: add help key to the env_config macro definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dotenv_config"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = [
   "Hengfei Yang <hengfei.yang@gmail.com>",
 ]
 description = "parse `env` to config struct for Rust"
-homepage = "https://github.com/zinclabs/dotenv-config/"
-repository = "https://github.com/zinclabs/dotenv-config/"
+homepage = "https://github.com/openobserve/dotenv-config/"
+repository = "https://github.com/openobserve/dotenv-config/"
 documentation = "https://docs.rs/dotenv_config"
 keywords = ["environment", "env", "dotenv", "settings", "config"]
 readme = "README.md"
@@ -21,7 +21,7 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1"
-askama = "0.11.1"           # Type-safe, compiled Jinja-like templates for Rust
+askama = "0.12.1"           # Type-safe, compiled Jinja-like templates for Rust
 convert_case = "0.6.0"      # Convert a string to snake_case, kebab-case, or camelCase
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ struct Config {
     server_mode: bool,
     #[env_config(name = "ZINC_FOO", default = true)]
     foo: bool,
-    #[env_config(name = "ZINC_BAR", default = 123456)]
+    #[env_config(name = "ZINC_BAR", default = 123456, help = "this is for demo")]
     bar: Option<i64>,
 }
 
@@ -25,6 +25,10 @@ fn main() {
     dotenv().ok();
     let cfg = Config::init().unwrap();
     println!("{:#?}", cfg);
+
+    // print config help
+    let help = Config::get_help();
+    println!("{:#?}", help);
 }
 ```
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.74.1"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -35,6 +35,7 @@ struct Fd {
     optional: bool,
     attr_name: String,
     attr_default: String,
+    attr_help: String, // new field for storing documentation comments
 }
 
 impl Fd {
@@ -45,6 +46,7 @@ impl Fd {
         // find env_config Group
         let mut attr_name: String = String::from("");
         let mut attr_default: String = String::from("");
+        let mut attr_help: String = String::from("");
         for item in name {
             if let TokenTree::Group(g) = item {
                 let mut g = g.stream().into_iter();
@@ -61,6 +63,9 @@ impl Fd {
                                     }
                                     "default" => {
                                         attr_default = item.1;
+                                    }
+                                    "help" => {
+                                        attr_help = item.1;
                                     }
                                     _ => {}
                                 }
@@ -99,6 +104,7 @@ impl Fd {
                     optional,
                     attr_name,
                     attr_default,
+                    attr_help,
                 }
             }
             e => panic!("Expect ident, but got {:?}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@
 //!     dotenv().ok();
 //!     let cfg = Config::init().unwrap();
 //!     println!("{:#?}", cfg);
+//! 
+//!     // print config help
+//!     let help = Config::get_help();
+//!     println!("{:#?}", help);
 //! }
 //! ```
 //!

--- a/templates/builder.j2
+++ b/templates/builder.j2
@@ -17,7 +17,8 @@ impl {{ name }} {
         {% else %}
             // Handle primitive types
             let key = "{{ field.attr_name }}".to_string();
-            let value = ("{{ field.attr_default }}".to_string(), Some("{{ field.attr_help }}".to_string()));
+            let help = {% if field.attr_help.is_empty() %} None {% else %} Some("{{ field.attr_help }}".to_string()) {% endif %};
+            let value = ("{{ field.attr_default }}".to_string(), help);
             help_map.insert(key, value);
         {% endif %}
         {% endfor %}

--- a/templates/builder.j2
+++ b/templates/builder.j2
@@ -1,4 +1,24 @@
+
+
 impl {{ name }} {
+
+    // Method to get help messages as a HashMap, where the key is the field name and the 
+    // value is a tuple of the default value and help message.
+    pub fn get_help() -> std::collections::HashMap<&'static str, (&'static str, &'static str)> {
+        let mut help_map = std::collections::HashMap::new();
+        let mut key: &str;
+        
+        {% for field in fields %}
+        {% if field.attr_name.is_empty() %}
+        key = "{{ uppersnake((name.clone() + "_" + field.name.as_str()).as_str()) }}";
+        {% else %}
+        key = "{{ field.attr_name }}";
+        {% endif %}
+        help_map.insert(key, ("{{ field.attr_default }}", "{{ field.attr_help }}"));
+        {% endfor %}
+        help_map
+    }
+    
     pub fn init() -> Result<{{ name }}, &'static str> {
         let mut key: &str;
         {% for field in fields %}

--- a/templates/builder.j2
+++ b/templates/builder.j2
@@ -4,17 +4,22 @@ impl {{ name }} {
 
     // Method to get help messages as a HashMap, where the key is the field name and the 
     // value is a tuple of the default value and help message.
-    pub fn get_help() -> std::collections::HashMap<&'static str, (&'static str, &'static str)> {
+    pub fn get_help() -> std::collections::HashMap<String, (String, Option<String>)> {
         let mut help_map = std::collections::HashMap::new();
-        let mut key: &str;
-        
+
         {% for field in fields %}
-        {% if field.attr_name.is_empty() %}
-        key = "{{ uppersnake((name.clone() + "_" + field.name.as_str()).as_str()) }}";
+        // If the field is a custom type, recursively get its help information.
+        {% if !contains(["usize", "i16", "i32", "i64", "u16", "u32", "u64", "f32", "f64", "bool", "String"], field.typ)  %}
+            let nested_help = {{ field.typ }}::get_help();
+            for (nested_key, nested_value) in nested_help {
+                help_map.insert(nested_key, nested_value);
+            }
         {% else %}
-        key = "{{ field.attr_name }}";
+            // Handle primitive types
+            let key = "{{ field.attr_name }}".to_string();
+            let value = ("{{ field.attr_default }}".to_string(), Some("{{ field.attr_help }}".to_string()));
+            help_map.insert(key, value);
         {% endif %}
-        help_map.insert(key, ("{{ field.attr_default }}", "{{ field.attr_help }}"));
         {% endfor %}
         help_map
     }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -6,7 +6,7 @@ struct Config {
     #[env_config(default = "192.168.2.1")]
     server_addr: String,
     server_mode: bool,
-    #[env_config(name = "ZINC_FOO", default = true)]
+    #[env_config(name = "ZINC_FOO", default = true, help = "foo is important")]
     foo: bool,
     #[env_config(name = "ZINC_BAR", default = 123456)]
     bar: Option<i64>,
@@ -34,4 +34,17 @@ fn test_config() {
     assert!(cfg.rr.port == "");
     assert!(cfg.rr.auth == "");
     assert!(cfg.rr.timeout == 30i32);
+
+    let help_keys = Config::get_help();
+    println!("help_keys: {:?}", help_keys);
+    assert!(help_keys.contains_key("ZINC_FOO"));
+    assert!(help_keys.contains_key("ZINC_BAR"));
+
+    let keys = help_keys.get("ZINC_BAR").unwrap();
+    assert_eq!(keys.0, "123456"); // default value
+    assert_eq!(keys.1, ""); // help value
+
+    let keys = help_keys.get("ZINC_FOO").unwrap();
+    assert_eq!(keys.0, "true"); // default value
+    assert_eq!(keys.1, "foo is important"); // help value
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -42,9 +42,9 @@ fn test_config() {
 
     let keys = help_keys.get("ZINC_BAR").unwrap();
     assert_eq!(keys.0, "123456"); // default value
-    assert_eq!(keys.1, ""); // help value
+    assert_eq!(keys.1, None); // help value
 
     let keys = help_keys.get("ZINC_FOO").unwrap();
     assert_eq!(keys.0, "true"); // default value
-    assert_eq!(keys.1, "foo is important"); // help value
+    assert_eq!(keys.1, Some("foo is important".to_string())); // help value
 }


### PR DESCRIPTION
Motivation behind this PR is to introduce an optional `help` field
in the `#[env_config()]` macro.

We can use this to automatically generate the configuration help
messages with their default values.

Also it prints the default values for the ENV-vars.